### PR TITLE
Add support for Arduino Outdoor Carrier

### DIFF
--- a/src/Arduino_SPIFFS.h
+++ b/src/Arduino_SPIFFS.h
@@ -59,17 +59,17 @@ static_assert(sizeof(u32_t) == sizeof(unsigned int), "Arduino SPIFFS Wrapper - s
  * CONSTANTS
  **************************************************************************************/
 
-static uint16_t constexpr APPEND        = SPIFFS_O_APPEND;
-static uint16_t constexpr TRUNCATE      = SPIFFS_O_TRUNC;
-static uint16_t constexpr CREATE        = SPIFFS_O_CREAT;
-static uint16_t constexpr READ_ONLY     = SPIFFS_O_RDONLY;
-static uint16_t constexpr WRITE_ONLY    = SPIFFS_O_WRONLY;
-static uint16_t constexpr READ_WRITE    = SPIFFS_O_RDWR;
+static uint16_t constexpr APPEND     = SPIFFS_O_APPEND;
+static uint16_t constexpr TRUNCATE   = SPIFFS_O_TRUNC;
+static uint16_t constexpr CREATE     = SPIFFS_O_CREAT;
+static uint16_t constexpr READ_ONLY  = SPIFFS_O_RDONLY;
+static uint16_t constexpr WRITE_ONLY = SPIFFS_O_WRONLY;
+static uint16_t constexpr READ_WRITE = SPIFFS_O_RDWR;
 #ifdef DIRECT
 #undef DIRECT
 #endif
-static uint16_t constexpr DIRECT        = SPIFFS_O_DIRECT; /* Any writes to the filehandle will never be cached but flushed directly */
-static uint16_t constexpr EXCLUSIVE     = SPIFFS_O_EXCL;
+static uint16_t constexpr DIRECT     = SPIFFS_O_DIRECT; /* Any writes to the filehandle will never be cached but flushed directly */
+static uint16_t constexpr EXCLUSIVE  = SPIFFS_O_EXCL;
 
 /**************************************************************************************
  * CLASS DECLARATION

--- a/src/Arduino_SPIFFS.h
+++ b/src/Arduino_SPIFFS.h
@@ -65,7 +65,10 @@ static uint16_t constexpr CREATE        = SPIFFS_O_CREAT;
 static uint16_t constexpr READ_ONLY     = SPIFFS_O_RDONLY;
 static uint16_t constexpr WRITE_ONLY    = SPIFFS_O_WRONLY;
 static uint16_t constexpr READ_WRITE    = SPIFFS_O_RDWR;
-static uint16_t constexpr WRITE_DIRECT  = SPIFFS_O_DIRECT; /* Any writes to the filehandle will never be cached but flushed directly */
+#ifdef DIRECT
+#undef DIRECT
+#endif
+static uint16_t constexpr DIRECT        = SPIFFS_O_DIRECT; /* Any writes to the filehandle will never be cached but flushed directly */
 static uint16_t constexpr EXCLUSIVE     = SPIFFS_O_EXCL;
 
 /**************************************************************************************

--- a/src/Arduino_SPIFFS.h
+++ b/src/Arduino_SPIFFS.h
@@ -59,14 +59,14 @@ static_assert(sizeof(u32_t) == sizeof(unsigned int), "Arduino SPIFFS Wrapper - s
  * CONSTANTS
  **************************************************************************************/
 
-static uint16_t constexpr APPEND     = SPIFFS_O_APPEND;
-static uint16_t constexpr TRUNCATE   = SPIFFS_O_TRUNC;
-static uint16_t constexpr CREATE     = SPIFFS_O_CREAT;
-static uint16_t constexpr READ_ONLY  = SPIFFS_O_RDONLY;
-static uint16_t constexpr WRITE_ONLY = SPIFFS_O_WRONLY;
-static uint16_t constexpr READ_WRITE = SPIFFS_O_RDWR;
-static uint16_t constexpr DIRECT     = SPIFFS_O_DIRECT; /* Any writes to the filehandle will never be cached but flushed directly */
-static uint16_t constexpr EXCLUSIVE  = SPIFFS_O_EXCL;
+static uint16_t constexpr APPEND        = SPIFFS_O_APPEND;
+static uint16_t constexpr TRUNCATE      = SPIFFS_O_TRUNC;
+static uint16_t constexpr CREATE        = SPIFFS_O_CREAT;
+static uint16_t constexpr READ_ONLY     = SPIFFS_O_RDONLY;
+static uint16_t constexpr WRITE_ONLY    = SPIFFS_O_WRONLY;
+static uint16_t constexpr READ_WRITE    = SPIFFS_O_RDWR;
+static uint16_t constexpr WRITE_DIRECT  = SPIFFS_O_DIRECT; /* Any writes to the filehandle will never be cached but flushed directly */
+static uint16_t constexpr EXCLUSIVE     = SPIFFS_O_EXCL;
 
 /**************************************************************************************
  * CLASS DECLARATION

--- a/src/Arduino_W25Q16DV.cpp
+++ b/src/Arduino_W25Q16DV.cpp
@@ -190,7 +190,13 @@ void Arduino_W25Q16DV::enableWrite()
  * EXTERN DECLARATION
  **************************************************************************************/
 
-Arduino_W25Q16DV flash(SPI, MKRMEM_W25Q16DV_CS_PIN);
+Arduino_W25Q16DV flash(SPI,
+#if defined(ARDUINO_OUTDOOR_CARRIER)
+OUTDOOR_CARRIER_W25Q16DV_CS_PIN
+#else
+MKRMEM_W25Q16DV_CS_PIN
+#endif
+);
 
 /**************************************************************************************
  * FREE FUNCTION DEFINITION

--- a/src/Arduino_W25Q16DV.h
+++ b/src/Arduino_W25Q16DV.h
@@ -72,8 +72,11 @@ typedef union
 /**************************************************************************************
  * CONSTANTS
  **************************************************************************************/
-
+#if defined(ARDUINO_OUTDOOR_CARRIER)
+static int const OUTDOOR_CARRIER_W25Q16DV_CS_PIN = 28;
+#else
 static int const MKRMEM_W25Q16DV_CS_PIN = 5;
+#endif
 
 /**************************************************************************************
  * CLASS DECLARATION


### PR DESCRIPTION
Add support for SPIFFS/W25Q16DV on Arduino Outdoor Carrier.