### PR TITLE
Fix spell check false positive by ignoring word

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,7 +1,7 @@
 # See: https://github.com/codespell-project/codespell#using-a-config-file
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
-ignore-words-list = thru,creat,pixes,objec,conjuction,indicies
+ignore-words-list = thru,creat,pixes,objec,conjuction,indicies,wel
 check-filenames =
 check-hidden =
 skip = ./.git


### PR DESCRIPTION
In the latest release of [the **codespell** tool](https://github.com/codespell-project/codespell) used for automated spell checking of the files of this project, the word "wel" was added to the codespell misspelled words dictionary as a misspelling of "well".

This caused a false detection of the struct member name `WEL` as a misspelling, resulting in a failing spell check result:

https://github.com/arduino-libraries/Arduino_MKRMEM/runs/8087303069?check_suite_focus=true#step:4:17

```text
Error: ./src/Arduino_W25Q16DV.h:61: WEL ==> WELL
```

Since the occurrence of this name is correct and intended in this project, the false positive is resolved by configuring codespell to ignore the problematic word.