### PR TITLE
Change maintainer to `Arduino <info@arduino.cc>`

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 name=Arduino_MKRMEM
 version=1.1.0
 author=Alexander Entinger <a.entinger@arduino.cc>
-maintainer=Alexander Entinger <a.entinger@arduino.cc>
+maintainer=Arduino <info@arduino.cc>
 sentence=SPIFFS on W25Q16DV for Arduino MKR MEM Shield.
 paragraph=Arduino library for the W25Q16DV flash on the MKR MEM Shield utilizing the SPIFFS flash file system.
 category=Communication


### PR DESCRIPTION
Maintainer is changed from `Alexander Entinger <a.entinger@arduino.cc>` to `Arduino <info@arduino.cc>` within the `library.properties` file. 